### PR TITLE
add path for mkdir

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -14,6 +14,7 @@ define facts::instance (
   exec { "${name} mkdir -p /etc/facter/facts.d/":
     command => 'mkdir -p /etc/facter/facts.d/',
     creates => '/etc/facter/facts.d/',
+    path    => '/bin',
   }
 
   file { "${facterpath}/${factname}.txt":


### PR DESCRIPTION
On ubuntu 13.10 the mkdir does not work as puppet does not use a default path. This change adds the path to the exec function.
NB: more common paths could be added there, I am not sure where mkdir resides on other distros
