### PR TITLE
adapt doc for act declaration without hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ facts::external::instance:
 The Defined Type is available as facts::external, allowing your Puppet classes to create arbitrary Puppet Facts. e.g.
 
 ```
-facts::external { 'mypuppetclass_applied':
+facts::instance { 'mypuppetclass_applied':
   value => true,
 }
-facts::external { 'mypuppetclass_applied_timestamp':
+facts::instance { 'mypuppetclass_applied_timestamp':
   value => strftime("%Y-%m-%d"),
 }
 ```


### PR DESCRIPTION
facts::external does not work for me when called from a manifest. Looking at the code it does a hiera lookup then calls facts::instance.

Using facts::instance works though

This is a proposal to adapt the doc accordingly
