### PR TITLE
Add metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,5 +5,6 @@
   "source": "none",
   "license": "GPL-2.0",
   "summary": "Create arbitrary Puppet Facts from Hiera or Puppet Classes",
-  "description": "This module allows you to create arbitrary Puppet Facts using Puppet code or your Hiera backend. This can be useful to document your machines or even your Puppet classes. A class could for example create it's own Fact, which when queried by a different class, could determine if the class has been applied to the machine or any other state that might be interesting to report."
+  "description": "This module allows you to create arbitrary Puppet Facts using Puppet code or your Hiera backend. This can be useful to document your machines or even your Puppet classes. A class could for example create it's own Fact, which when queried by a different class, could determine if the class has been applied to the machine or any other state that might be interesting to report.",
+  "dependencies": []
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,9 @@
+{
+  "name": "meltwater-facts",
+  "version": "0.1.1",
+  "author": "meltwater",
+  "source": "none",
+  "license": "GPL-2.0",
+  "summary": "Create arbitrary Puppet Facts from Hiera or Puppet Classes",
+  "description": "This module allows you to create arbitrary Puppet Facts using Puppet code or your Hiera backend. This can be useful to document your machines or even your Puppet classes. A class could for example create it's own Fact, which when queried by a different class, could determine if the class has been applied to the machine or any other state that might be interesting to report."
+}


### PR DESCRIPTION
Contains identical information as Modulefile. Fixes warning when using Librarian-Puppet and Puppet 4.

> Can't parse Modulefile in Puppet >= 4.0 and you are using 4.4.1. Ignoring dependencies in /Users/bdericks/repos/puppet-control/.tmp/librarian/cache/source/git/8504de28dbeb368b/Modulefile
> Module https://github.com/genome-vendor/puppet-facts#file_owner does not have version, defaulting to 0.0.1
