### PR TITLE
allow structured facts via json or yaml

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -1,10 +1,11 @@
 # == Defined Type facts
 #
 define facts::instance (
-  $ensure = present,
+  $ensure     = present,
   $facterpath = '/etc/facter/facts.d',
-  $factname = $name,
-  $value = undef,
+  $factname   = $name,
+  $value      = undef,
+  $format     = 'txt',
 ) {
 
   if versioncmp($::facterversion, '1.7') == -1 {
@@ -16,12 +17,33 @@ define facts::instance (
     creates => '/etc/facter/facts.d/',
     path    => '/bin',
   }
-
-  file { "${facterpath}/${factname}.txt":
-    ensure  => $ensure,
-    content => "${factname}=${value}",
-    group   => 'root',
-    mode    => '0664',
-    owner   => 'root',
+  case $format {
+    default: { 
+      file { "${facterpath}/${factname}.${format}":
+        ensure  => $ensure,
+        content => "${factname}=${value}",
+        group   => 'root',
+        mode    => '0664',
+        owner   => 'root',
+      }
+    }
+  'yaml': {
+    file { "${facterpath}/${factname}.${format}":
+      ensure  => $ensure,
+      content => inline_template('<%= { @factname => @value}.to_yaml %>'),
+      group   => 'root',
+      mode    => '0664',
+      owner   => 'root',
+    }
+  }
+  'json': {
+    file { "${facterpath}/${factname}.${format}":
+      ensure  => $ensure,
+      content => inline_template('<%= { @factname => @value}.to_json %>'),
+      group   => 'root',
+      mode    => '0664',
+      owner   => 'root',
+    }
+  }
   }
 }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -12,13 +12,13 @@ define facts::instance (
     fail('facts::instance requires a Facter version >= 1.7')
   }
 
-  exec { "${name} mkdir -p /etc/facter/facts.d/":
-    command => 'mkdir -p /etc/facter/facts.d/',
-    creates => '/etc/facter/facts.d/',
+  exec { "${name} mkdir -p ${facterpath}":
+    command => "mkdir -p ${facterpath}",
+    creates => $facterpath,
     path    => '/bin',
   }
   case $format {
-    default: { 
+    default: {
       file { "${facterpath}/${factname}.${format}":
         ensure  => $ensure,
         content => "${factname}=${value}",

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -27,23 +27,23 @@ define facts::instance (
         owner   => 'root',
       }
     }
-  'yaml': {
-    file { "${facterpath}/${factname}.${format}":
-      ensure  => $ensure,
-      content => inline_template('<%= { @factname => @value}.to_yaml %>'),
-      group   => 'root',
-      mode    => '0664',
-      owner   => 'root',
+    'yaml': {
+      file { "${facterpath}/${factname}.${format}":
+        ensure  => $ensure,
+        content => inline_template('<%= { @factname => @value}.to_yaml %>'),
+        group   => 'root',
+        mode    => '0664',
+        owner   => 'root',
+      }
     }
-  }
-  'json': {
-    file { "${facterpath}/${factname}.${format}":
-      ensure  => $ensure,
-      content => inline_template('<%= { @factname => @value}.to_json %>'),
-      group   => 'root',
-      mode    => '0664',
-      owner   => 'root',
+    'json': {
+      file { "${facterpath}/${factname}.${format}":
+        ensure  => $ensure,
+        content => inline_template('<%= { @factname => @value}.to_json %>'),
+        group   => 'root',
+        mode    => '0664',
+        owner   => 'root',
+      }
     }
-  }
   }
 }


### PR DESCRIPTION
These changes enable dropping yaml or json files in the facts.d directory. One disadvantage to txt facts is that there are no true boolean values, which has broken some of our code that expects a boolean vs. a string.